### PR TITLE
Add Delay Capability and Update Tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,54 +1,63 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
 //const got = require('got');
-const {parse} = require("node-html-parser");
-const {CookieJar} = require('tough-cookie');
+const { parse } = require("node-html-parser");
+const { CookieJar } = require('tough-cookie');
+const delay_run_ms = core.getInput('delay-run-ms') || core.getInput('delay_run_ms');
 
 const flowLibraryUrl = 'https://flows.nodered.org/add/node';
 
-(async () => {
-    try {
-        const packageName = core.getInput('package-name') || core.getInput('package_name');
-        if (packageName === undefined || packageName === '') {
-            core.setFailed("No package name provided.");
-            return;
-        }
-        try {
-            const { got } = await import("got");
-            const cookieJar = new CookieJar();
-            const response = await got(flowLibraryUrl, {cookieJar});
-            const root = parse(response.body);
-            const csrf = root.querySelector('#add-node-csrf').getAttribute('value');
-            if (csrf !== undefined) {
-                const response2 = await got.post(flowLibraryUrl, {
-                    cookieJar,
-                    form: {
-                        module: packageName,
-                        _csrf: csrf
-                    }
-                });
+if (delay_run_ms === '') {
+    console.log('No delay defined, running immediately');
+} else {
+    console.log('Delaying for ' + delay_run_ms + ' ms');
+}
 
-                let result = response2.body.trim();
-                if (result.substr(1, 8 + packageName.length) === 'node/' + packageName + '?m=') {
-                    try {
-                        let msg = atob(result.substr(9 + packageName.length));
-                        console.log(`result = "${msg}"`);
-                        core.setOutput('result', msg);
-                    } catch (e) {
+setTimeout(function () {
+    (async () => {
+        try {
+            const packageName = core.getInput('package-name') || core.getInput('package_name');
+            if (packageName === undefined || packageName === '') {
+                core.setFailed("No package name provided.");
+                return;
+            }
+            try {
+                const { got } = await import("got");
+                const cookieJar = new CookieJar();
+                const response = await got(flowLibraryUrl, { cookieJar });
+                const root = parse(response.body);
+                const csrf = root.querySelector('#add-node-csrf').getAttribute('value');
+                if (csrf !== undefined) {
+                    const response2 = await got.post(flowLibraryUrl, {
+                        cookieJar,
+                        form: {
+                            module: packageName,
+                            _csrf: csrf
+                        }
+                    });
+
+                    let result = response2.body.trim();
+                    if (result.substr(1, 8 + packageName.length) === 'node/' + packageName + '?m=') {
+                        try {
+                            let msg = atob(result.substr(9 + packageName.length));
+                            console.log(`result = "${msg}"`);
+                            core.setOutput('result', msg);
+                        } catch (e) {
+                            console.log(`result = "${result}"`);
+                            core.setOutput('result', result);
+                        }
+                    } else {
                         console.log(`result = "${result}"`);
                         core.setOutput('result', result);
                     }
-                } else {
-                    console.log(`result = "${result}"`);
-                    core.setOutput('result', result);
-                }
 
+                }
+            } catch (error) {
+                console.log(`result = "${error.response.body}"`);
+                core.setOutput('result', error.response.body);
             }
         } catch (error) {
-            console.log(`result = "${error.response.body}"`);
-            core.setOutput('result', error.response.body);
+            core.setFailed(error.message);
         }
-    } catch (error) {
-        core.setFailed(error.message);
-    }
-})();
+    })();
+}, delay_run_ms || 0);

--- a/test/updateflow.test.js
+++ b/test/updateflow.test.js
@@ -1,16 +1,46 @@
-test('Running should fail since package name not provided', async () => {
-  //console.log('Running test: Running should fail since package name not provided');
-  const spawnSync = require('child_process').spawnSync;  
-  const myResult = spawnSync('npm run start', { stdio: "pipe", shell: true });
-  //console.log(myResult.output.toString());
-  expect(myResult.output.toString().includes('No package name provided')).toBeTruthy();
-});
+describe('Running Tests', () => {
+  const OLD_ENV = process.env;
+  let spawnSync;
 
-test('Running should update flow', async () => {
-  //console.log('Running test: Running should update flow');
-  const spawnSync = require('child_process').spawnSync;
-  const envVars = Object.assign({}, process.env, { INPUT_PACKAGE_NAME: 'node-red-contrib-onstar2' });
-  const myResult = spawnSync('npm run start', { stdio: "pipe", shell: true, env: envVars });
-  //console.log(myResult.output.toString());
-  expect(myResult.output.toString().includes('Module already at latest version')).toBeTruthy();
+  beforeEach(() => {
+    jest.resetModules() // Most important - it clears the cache
+    spawnSync = require('child_process').spawnSync;
+    process.env = { ...OLD_ENV }; // Make a copy
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  test('Running should fail since package name not provided - No Delay', async () => {
+    //console.log('Running test: Running should fail since package name not provided');
+    const myResult = spawnSync('npm run start', { stdio: "pipe", shell: true });
+    //console.log(myResult.output.toString());
+    expect(myResult.output.toString().includes('No package name provided' && 'No delay defined, running immediately')).toBeTruthy();
+  });
+
+  test('Running should fail since package name not provided - With 2000 ms Delay', async () => {
+    //console.log('Running test: Running should fail since package name not provided');
+    const envVars = Object.assign({}, process.env, { INPUT_DELAY_RUN_MS: 2000 });
+    const myResult = spawnSync('npm run start', { stdio: "pipe", shell: true, env: envVars });
+    //console.log(myResult.output.toString());
+    expect(myResult.output.toString().includes('No package name provided' && 'Delaying for 2000 ms')).toBeTruthy();
+  });
+
+  test('Running should update flow - No Delay', async () => {
+    //console.log('Running test: Running should update flow');
+    const envVars = Object.assign({}, process.env, { INPUT_PACKAGE_NAME: 'node-red-contrib-onstar2' });
+    const myResult = spawnSync('npm run start', { stdio: "pipe", shell: true, env: envVars });
+    //console.log(myResult.output.toString());
+    expect(myResult.output.toString().includes('Module already at latest version')).toBeTruthy();
+  });
+
+  test('Running should update flow - With 2000 ms Delay', async () => {
+    //console.log('Running test: Running should update flow');
+    const spawnSync = require('child_process').spawnSync;
+    const envVars = Object.assign({}, process.env, { INPUT_PACKAGE_NAME: 'node-red-contrib-onstar2', INPUT_DELAY_RUN_MS: 2000 });
+    const myResult = spawnSync('npm run start', { stdio: "pipe", shell: true, env: envVars });
+    //console.log(myResult.output.toString());
+    expect(myResult.output.toString().includes('Module already at latest version' && 'Delaying for 2000 ms')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
- Added the capability to delay running the action when necessary to allow the flow library to be able to see that a new package has been published to avoid the flow library not updating due to new package not yet seen
  - Default Value - No Delay
  - If inserting a delay is necessary - Use parameter 'delay-run-ms' which is the required delay in milliseconds
- Updated tests to include new functionality